### PR TITLE
fix: accommodate JSON hand parsing

### DIFF
--- a/connectors/sql-stored-connector/src/main/resources/camel-connector.json
+++ b/connectors/sql-stored-connector/src/main/resources/camel-connector.json
@@ -16,9 +16,7 @@
   "inputDataType" : "json",
   "outputDataType" : "json",
   "componentOptions" : [ "dataSource" ],
-  "endpointOptions" : [ "procedureName", "template", "batch", "noop" ],
-  "endpointValues" : {},
-
+  "endpointOptions" : [ "procedureName", "template" ],
   "connectorProperties" : {
     "user" : {
       "kind" : "property",


### PR DESCRIPTION
As Connector JSON is parsed by hand it needs to be in certain format, we
are not setting `endpointValues` so best remove them.

Also removes `noop` and `batch` options.